### PR TITLE
Update to add BUILD_TEAM_NAME variable, available since Concourse v2.3.0

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -67,7 +67,7 @@ resources:
     color: green
     from: "Concourse CI"
     message:
-      template: "${PR-TITLE} Build Successful - <a href='${ATC_EXTERNAL_URL}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}'>Build Logs</a>"
+      template: "${PR-TITLE} Build Successful - <a href='${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}'>Build Logs</a>"
       params:
         PR-TITLE: file://output-directory/pr-title
 ```

--- a/scripts/tokenReplacement.js
+++ b/scripts/tokenReplacement.js
@@ -32,7 +32,8 @@ module.exports = {
       "${BUILD_NAME}": process.env.BUILD_NAME,
       "${BUILD_JOB_NAME}": process.env.BUILD_JOB_NAME,
       "${BUILD_PIPELINE_NAME}": process.env.BUILD_PIPELINE_NAME,
-      "${ATC_EXTERNAL_URL}": process.env.ATC_EXTERNAL_URL
+      "${ATC_EXTERNAL_URL}": process.env.ATC_EXTERNAL_URL,
+      "${BUILD_TEAM_NAME}": process.env.BUILD_TEAM_NAME
     };
 
     for (var t in buildTokens) {


### PR DESCRIPTION
The BUILD_TEAM_NAME env var was added in Concourse 2.3.0.

See [Concourse Downloads](https://concourse.ci/downloads.html#v230)

This PR adds support for that flag so that the links to the build documents will function in current Concourse versions.